### PR TITLE
Add runnable dashboard and payment checkout readiness (Stripe & PayPal)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,24 @@ ANTHROPIC_API_KEY=your-anthropic-api-key-here
 # Application Settings
 NODE_ENV=development
 PORT=3000
+
+# Stripe Checkout Configuration
+STRIPE_PUBLISHABLE_KEY=pk_test_your-stripe-publishable-key
+STRIPE_SECRET_KEY=sk_test_your-stripe-secret-key
+STRIPE_CHECKOUT_MODE=subscription
+STRIPE_DEFAULT_PRICE_ID=price_your-default-price-id
+STRIPE_PRICE_STARTER=price_your-starter-price-id
+STRIPE_PRICE_PRO=price_your-pro-price-id
+STRIPE_PRICE_AGENCY=price_your-agency-price-id
+
+# PayPal Checkout Configuration
+PAYPAL_ENVIRONMENT=sandbox
+PAYPAL_CLIENT_ID=your-paypal-client-id
+PAYPAL_CLIENT_SECRET=your-paypal-client-secret
+PAYPAL_CURRENCY=USD
+PAYPAL_PRICE_STARTER=29.00
+PAYPAL_PRICE_PRO=99.00
+PAYPAL_PRICE_AGENCY=299.00
+
+# Public application URL for checkout return/cancel links
+APP_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -3,4 +3,29 @@ No-code AI assistant website and smart app developers toolbox. A platform I can 
 with a YouTube extension for video training session's, tutorial s, and webadars. add the Claude AI assistant API for the host and code no-code assistant in the program and a ninja ai and Gemini and Agent. Google calendar. a Google workspace and Microsoft 365, office, Google cloud, Okta zero trust and cloudedlare 1111 zero integration for collaboration on projects. 
 I want to be able to verify my domain instantly with a connecting portal to iccann registry. I wanna be able to have the lowest domain prices in the business. With my program hosted by Google Gemini 2.5 flash on premium with no limits or unlimited credits. I want you to connect a elfsite widget so I can use there widget Maker.Make sure you put the right amount of security measures best practice. Make sure it's evenly secure all the way around. add the five best assistants for coding. every free with a subscription and or membership. With YouTube connected and Spotify for they developer profile to connect it. everything automated and greats users through the front door. all the AI Perplexity on agent mode for advanced coding assistant. All personalized to one user forever, and really loyal attitude. Focus driven to complete each task until each project is complete. when you sign in and login in this is passwordless users are automatically assigned to a passkey or there preferred company login for example Google sign in Microsoft Okta zero trust passwordless.like adopting Okta principles and standards and strategies and strength,biometrics. 
 user is at the login screen chooses make a account picks a domain or email or to have us build their website or app or use our AI to coach them through building their own apps and websites. after login it's the counter the menus . This is the list of services that we offer on the platform. A website builder DNS setup and the DNS finder tool like inside the Google admin center. email and domain service the elfsite widget maker. And every AI can talk and operate outside the app screen to better help with task to complete project faster.
- 
+
+
+## Current dashboard build
+
+This repository now includes a runnable Node.js dashboard for RemoVision's Code Finders Platform.
+It serves a project command center, AI assistant readiness checks, and payment-ready upper-tier plan cards.
+
+```bash
+npm install
+cp .env.example .env
+npm run dev
+```
+
+Open `http://localhost:3000` and use the payment cards to verify Stripe or PayPal readiness. Without real credentials, the checkout endpoints safely return setup guidance instead of attempting a live payment.
+
+## Payment connection overview
+
+- `POST /api/checkout/stripe` creates a Stripe Checkout Session when `STRIPE_SECRET_KEY` and a Stripe price ID are configured.
+- `POST /api/checkout/paypal` creates a PayPal order when `PAYPAL_CLIENT_ID` and `PAYPAL_CLIENT_SECRET` are configured.
+- `GET /api/config` reports dashboard readiness without exposing private secrets.
+
+Keep all API keys in `.env`; never commit private keys to Git.
+
+## Termux quick command
+
+See [`TERMUX.md`](./TERMUX.md) for a ready-to-run Codex prompt and Termux setup commands.

--- a/SETUP.md
+++ b/SETUP.md
@@ -164,6 +164,28 @@ chatWithClaude();
 4. Create a new key
 5. Copy and paste it in `.env` as `ANTHROPIC_API_KEY`
 
+## Dashboard and Payment Setup
+
+The dashboard is available after `npm run dev` at `http://localhost:3000`. It includes payment-ready upper-tier plan cards. Stripe and PayPal remain disabled until real credentials are added to `.env`.
+
+Required Stripe variables:
+
+```env
+STRIPE_SECRET_KEY=sk_test_or_live_key
+STRIPE_DEFAULT_PRICE_ID=price_default
+STRIPE_PRICE_PRO=price_upper_tier
+```
+
+Required PayPal variables:
+
+```env
+PAYPAL_ENVIRONMENT=sandbox
+PAYPAL_CLIENT_ID=your-client-id
+PAYPAL_CLIENT_SECRET=your-client-secret
+```
+
+Use sandbox credentials first, then switch to live provider credentials after testing.
+
 ## Available npm Scripts
 
 ```bash
@@ -180,7 +202,9 @@ RemoVisions-Code-Finders-Platform/
 ├── .gitignore           # Git ignore rules
 ├── package.json         # Project dependencies
 ├── SETUP.md            # This file
-└── index.js            # Main entry point (to be created)
+├── TERMUX.md           # Termux and Codex command guide
+├── public/             # Dashboard frontend assets
+└── index.js            # Main dashboard and payment API server
 ```
 
 ## Troubleshooting

--- a/TERMUX.md
+++ b/TERMUX.md
@@ -1,0 +1,61 @@
+# Command Codex in Termux
+
+Use this quick path when you want Codex to build or revise the RemoVision dashboard from an Android Termux shell.
+
+## 1. Install the required tools
+
+```bash
+pkg update && pkg upgrade -y
+pkg install -y nodejs git
+npm install -g @openai/codex
+```
+
+## 2. Clone and prepare the platform
+
+```bash
+git clone https://github.com/removisionscodefindersplatform-art/RemoVisions-Code-Finders-Platform.git
+cd RemoVisions-Code-Finders-Platform
+npm install
+cp .env.example .env
+nano .env
+```
+
+Add your private keys only inside `.env`; do not paste secrets into a Codex chat prompt.
+
+## 3. Use this Codex command
+
+```bash
+codex "Build RemoVision's dashboard, connect Stripe and PayPal checkout readiness for upper tier payments, keep secrets in .env only, run npm test, commit changes, and write a PR summary."
+```
+
+## 4. Required payment variables
+
+Stripe Checkout needs:
+
+```env
+STRIPE_PUBLISHABLE_KEY=pk_test_...
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_DEFAULT_PRICE_ID=price_...
+STRIPE_PRICE_STARTER=price_...
+STRIPE_PRICE_PRO=price_...
+STRIPE_PRICE_AGENCY=price_...
+```
+
+PayPal Checkout needs:
+
+```env
+PAYPAL_ENVIRONMENT=sandbox
+PAYPAL_CLIENT_ID=...
+PAYPAL_CLIENT_SECRET=...
+PAYPAL_CURRENCY=USD
+```
+
+Switch `PAYPAL_ENVIRONMENT` to `live` only after sandbox testing succeeds.
+
+## 5. Run the dashboard
+
+```bash
+npm run dev
+```
+
+Open the URL shown in the terminal. In Termux, expose it with a tunnel or deploy it to a host before using live payment return URLs.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,343 @@
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { request as httpsRequest } from 'node:https';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const publicDir = path.join(__dirname, 'public');
+const PORT = Number(process.env.PORT || 3000);
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+};
+
+const tiers = {
+  starter: {
+    name: 'Starter Builder',
+    price: '$29/mo',
+    description: 'Launch a guided website or app with AI planning, DNS checklists, and project coaching.',
+    features: ['AI build plan', 'DNS setup checklist', 'Dashboard project tracker'],
+  },
+  pro: {
+    name: 'Upper Tier Pro',
+    price: '$99/mo',
+    description: 'Adds multi-agent code support, training integrations, and priority implementation guidance.',
+    features: ['Five coding assistants', 'YouTube training hub', 'Priority project workflow'],
+  },
+  agency: {
+    name: 'Agency Command',
+    price: '$299/mo',
+    description: 'For teams selling sites, apps, domains, widgets, and integrations from one command center.',
+    features: ['Client workspaces', 'Payment-ready offers', 'Domain and DNS launch board'],
+  },
+};
+
+function json(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  res.end(JSON.stringify(payload, null, 2));
+}
+
+function getPublicConfig() {
+  const stripeReady = Boolean(process.env.STRIPE_SECRET_KEY);
+  const paypalReady = Boolean(process.env.PAYPAL_CLIENT_ID && process.env.PAYPAL_CLIENT_SECRET);
+
+  return {
+    appName: 'RemoVision\'s Code Finders Platform',
+    environment: process.env.NODE_ENV || 'development',
+    payments: {
+      stripe: {
+        ready: stripeReady,
+        publishableKeyConfigured: Boolean(process.env.STRIPE_PUBLISHABLE_KEY),
+        checkoutMode: process.env.STRIPE_CHECKOUT_MODE || 'subscription',
+      },
+      paypal: {
+        ready: paypalReady,
+        clientIdConfigured: Boolean(process.env.PAYPAL_CLIENT_ID),
+        environment: process.env.PAYPAL_ENVIRONMENT || 'sandbox',
+      },
+    },
+    aiAssistants: {
+      openai: Boolean(process.env.OPENAI_API_KEY),
+      gemini: Boolean(process.env.GOOGLE_API_KEY),
+      claude: Boolean(process.env.ANTHROPIC_API_KEY),
+    },
+    tiers,
+  };
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch {
+    const error = new Error('Request body must be valid JSON.');
+    error.statusCode = 400;
+    throw error;
+  }
+}
+
+function normalizeTier(tier) {
+  if (typeof tier !== 'string' || !tiers[tier]) {
+    return 'pro';
+  }
+
+  return tier;
+}
+
+function httpsJsonRequest({ hostname, path: requestPath, method = 'GET', headers = {}, body }) {
+  return new Promise((resolve, reject) => {
+    const req = httpsRequest(
+      {
+        hostname,
+        path: requestPath,
+        method,
+        headers: {
+          Accept: 'application/json',
+          ...headers,
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          const data = raw ? JSON.parse(raw) : {};
+
+          if (res.statusCode >= 400) {
+            const error = new Error(data.error?.message || data.message || 'Payment provider request failed.');
+            error.statusCode = res.statusCode;
+            error.details = data;
+            reject(error);
+            return;
+          }
+
+          resolve(data);
+        });
+      },
+    );
+
+    req.on('error', reject);
+
+    if (body) {
+      req.write(body);
+    }
+
+    req.end();
+  });
+}
+
+async function createStripeCheckoutSession(tierKey) {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    return {
+      provider: 'stripe',
+      ready: false,
+      message: 'Add STRIPE_SECRET_KEY plus tier price IDs to .env to enable Stripe Checkout.',
+      tier: tiers[tierKey],
+    };
+  }
+
+  const priceId = process.env[`STRIPE_PRICE_${tierKey.toUpperCase()}`] || process.env.STRIPE_DEFAULT_PRICE_ID;
+
+  if (!priceId) {
+    return {
+      provider: 'stripe',
+      ready: false,
+      message: `Stripe is configured, but no price ID was found for ${tierKey}. Add STRIPE_PRICE_${tierKey.toUpperCase()} or STRIPE_DEFAULT_PRICE_ID.`,
+      tier: tiers[tierKey],
+    };
+  }
+
+  const baseUrl = process.env.APP_BASE_URL || `http://localhost:${PORT}`;
+  const body = new URLSearchParams({
+    mode: process.env.STRIPE_CHECKOUT_MODE || 'subscription',
+    success_url: `${baseUrl}/?checkout=stripe-success&tier=${tierKey}`,
+    cancel_url: `${baseUrl}/?checkout=stripe-cancel&tier=${tierKey}`,
+    'line_items[0][price]': priceId,
+    'line_items[0][quantity]': '1',
+    'metadata[tier]': tierKey,
+  }).toString();
+
+  const session = await httpsJsonRequest({
+    hostname: 'api.stripe.com',
+    path: '/v1/checkout/sessions',
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.STRIPE_SECRET_KEY}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': Buffer.byteLength(body),
+    },
+    body,
+  });
+
+  return {
+    provider: 'stripe',
+    ready: true,
+    checkoutUrl: session.url,
+    sessionId: session.id,
+  };
+}
+
+async function getPayPalAccessToken() {
+  const credentials = Buffer.from(`${process.env.PAYPAL_CLIENT_ID}:${process.env.PAYPAL_CLIENT_SECRET}`).toString('base64');
+  const body = 'grant_type=client_credentials';
+  const host = process.env.PAYPAL_ENVIRONMENT === 'live' ? 'api-m.paypal.com' : 'api-m.sandbox.paypal.com';
+  const token = await httpsJsonRequest({
+    hostname: host,
+    path: '/v1/oauth2/token',
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': Buffer.byteLength(body),
+    },
+    body,
+  });
+
+  return { host, accessToken: token.access_token };
+}
+
+async function createPayPalOrder(tierKey) {
+  if (!process.env.PAYPAL_CLIENT_ID || !process.env.PAYPAL_CLIENT_SECRET) {
+    return {
+      provider: 'paypal',
+      ready: false,
+      message: 'Add PAYPAL_CLIENT_ID and PAYPAL_CLIENT_SECRET to .env to enable PayPal order creation.',
+      tier: tiers[tierKey],
+    };
+  }
+
+  const tierPrices = {
+    starter: process.env.PAYPAL_PRICE_STARTER || '29.00',
+    pro: process.env.PAYPAL_PRICE_PRO || '99.00',
+    agency: process.env.PAYPAL_PRICE_AGENCY || '299.00',
+  };
+  const { host, accessToken } = await getPayPalAccessToken();
+  const baseUrl = process.env.APP_BASE_URL || `http://localhost:${PORT}`;
+  const body = JSON.stringify({
+    intent: 'CAPTURE',
+    purchase_units: [
+      {
+        reference_id: tierKey,
+        description: tiers[tierKey].name,
+        amount: {
+          currency_code: process.env.PAYPAL_CURRENCY || 'USD',
+          value: tierPrices[tierKey],
+        },
+      },
+    ],
+    payment_source: {
+      paypal: {
+        experience_context: {
+          return_url: `${baseUrl}/?checkout=paypal-success&tier=${tierKey}`,
+          cancel_url: `${baseUrl}/?checkout=paypal-cancel&tier=${tierKey}`,
+        },
+      },
+    },
+  });
+
+  const order = await httpsJsonRequest({
+    hostname: host,
+    path: '/v2/checkout/orders',
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(body),
+    },
+    body,
+  });
+
+  return {
+    provider: 'paypal',
+    ready: true,
+    orderId: order.id,
+    approvalUrl: order.links?.find((link) => link.rel === 'payer-action' || link.rel === 'approve')?.href,
+  };
+}
+
+async function handleApi(req, res) {
+  if (req.method === 'GET' && req.url === '/api/config') {
+    json(res, 200, getPublicConfig());
+    return true;
+  }
+
+  if (req.method === 'POST' && req.url === '/api/checkout/stripe') {
+    const body = await readJsonBody(req);
+    json(res, 200, await createStripeCheckoutSession(normalizeTier(body.tier)));
+    return true;
+  }
+
+  if (req.method === 'POST' && req.url === '/api/checkout/paypal') {
+    const body = await readJsonBody(req);
+    json(res, 200, await createPayPalOrder(normalizeTier(body.tier)));
+    return true;
+  }
+
+  return false;
+}
+
+async function serveStatic(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const requestedPath = url.pathname === '/' ? '/index.html' : url.pathname;
+  const safePath = path.normalize(decodeURIComponent(requestedPath)).replace(/^[/\\]+/, '');
+  const filePath = path.join(publicDir, safePath);
+
+  if (!filePath.startsWith(publicDir)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  try {
+    const content = await readFile(filePath);
+    const ext = path.extname(filePath);
+    res.writeHead(200, {
+      'Content-Type': mimeTypes[ext] || 'application/octet-stream',
+      'Cache-Control': ext === '.html' ? 'no-cache' : 'public, max-age=3600',
+    });
+    res.end(content);
+  } catch {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Not found');
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const handled = await handleApi(req, res);
+    if (handled) {
+      return;
+    }
+
+    await serveStatic(req, res);
+  } catch (error) {
+    json(res, error.statusCode || 500, {
+      error: error.message || 'Unexpected server error',
+      details: process.env.NODE_ENV === 'development' ? error.details : undefined,
+    });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`RemoVision dashboard running at http://localhost:${PORT}`);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,921 @@
+{
+  "name": "removisions-code-finders-platform",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "removisions-code-finders-platform",
+      "version": "1.0.0",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.13.0",
+        "@google/generative-ai": "^0.3.0",
+        "dotenv": "^16.3.1",
+        "openai": "^4.52.0"
+      },
+      "devDependencies": {
+        "nodemon": "^3.0.2"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.13.1.tgz",
+      "integrity": "sha512-e8DgY8ZI339wYUufqiX8SPLXzWyiKLCy2zHYYzA3H3BVH+ryo3/TYwyGFfPqPcanLAt5AZlsCKo9+Bj05vbDhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "digest-fetch": "^1.3.0",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.3.1.tgz",
+      "integrity": "sha512-Zh1EK5nCWqIhxPm3K1KOM2mOwwgBvp6lkze74yTj6+Zqibtf55Db1q87cbbzWZeET3ZbNgHMYjVf2JyMM6pI7A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/digest-fetch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
+      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
+      "license": "ISC",
+      "dependencies": {
+        "base-64": "^0.1.0",
+        "md5": "^2.3.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "node --watch index.js",
+    "test": "node --check index.js",
     "install-agents": "npm install"
   },
   "keywords": [

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,87 @@
+const readinessList = document.querySelector('#readiness-list');
+const tierGrid = document.querySelector('#tier-grid');
+const checkoutResult = document.querySelector('#checkout-result');
+
+function badge(isReady) {
+  return `<span class="badge ${isReady ? 'ready' : 'missing'}">${isReady ? 'Ready' : 'Needs keys'}</span>`;
+}
+
+function renderReadiness(config) {
+  const items = [
+    ['Stripe checkout', config.payments.stripe.ready],
+    ['PayPal orders', config.payments.paypal.ready],
+    ['OpenAI assistant', config.aiAssistants.openai],
+    ['Gemini assistant', config.aiAssistants.gemini],
+    ['Claude assistant', config.aiAssistants.claude],
+  ];
+
+  readinessList.innerHTML = items
+    .map(([label, ready]) => `<div class="readiness-item"><strong>${label}</strong>${badge(ready)}</div>`)
+    .join('');
+}
+
+function renderTiers(tiers) {
+  tierGrid.innerHTML = Object.entries(tiers)
+    .map(([tierKey, tier]) => {
+      const features = tier.features.map((feature) => `<li>${feature}</li>`).join('');
+      return `
+        <article class="card tier-card">
+          <h3>${tier.name}</h3>
+          <div class="tier-price">${tier.price}</div>
+          <p>${tier.description}</p>
+          <ul>${features}</ul>
+          <div class="checkout-actions">
+            <button class="checkout-button stripe" data-provider="stripe" data-tier="${tierKey}">Start Stripe checkout</button>
+            <button class="checkout-button paypal" data-provider="paypal" data-tier="${tierKey}">Start PayPal checkout</button>
+          </div>
+        </article>
+      `;
+    })
+    .join('');
+}
+
+async function startCheckout(provider, tier) {
+  checkoutResult.textContent = `Preparing ${provider} checkout for ${tier}…`;
+
+  const response = await fetch(`/api/checkout/${provider}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tier }),
+  });
+  const result = await response.json();
+
+  if (!response.ok) {
+    checkoutResult.textContent = result.error || 'Checkout failed. Check server logs.';
+    return;
+  }
+
+  const checkoutUrl = result.checkoutUrl || result.approvalUrl;
+  if (checkoutUrl) {
+    checkoutResult.innerHTML = `Checkout ready. <a href="${checkoutUrl}">Open ${provider} checkout</a>.`;
+    return;
+  }
+
+  checkoutResult.textContent = result.message || `${provider} is not fully configured yet.`;
+}
+
+async function bootDashboard() {
+  const response = await fetch('/api/config');
+  const config = await response.json();
+  renderReadiness(config);
+  renderTiers(config.tiers);
+
+  tierGrid.addEventListener('click', (event) => {
+    const button = event.target.closest('[data-provider][data-tier]');
+    if (!button) {
+      return;
+    }
+
+    startCheckout(button.dataset.provider, button.dataset.tier).catch((error) => {
+      checkoutResult.textContent = error.message;
+    });
+  });
+}
+
+bootDashboard().catch((error) => {
+  readinessList.textContent = error.message;
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RemoVision's Code Finders Platform Dashboard</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <nav class="nav">
+        <strong>RemoVision's Code Finders Platform</strong>
+        <a href="#payments">Payments</a>
+        <a href="#builder">Builder</a>
+        <a href="#termux">Termux Command</a>
+      </nav>
+      <section class="hero-grid">
+        <div>
+          <p class="eyebrow">AI website, app, DNS, domain, and client build hub</p>
+          <h1>Command center for launching client projects with AI assistance and upper-tier payments.</h1>
+          <p class="lead">
+            Build websites and apps, coach clients through no-code workflows, track DNS/domain setup,
+            and prepare subscriptions through Stripe or PayPal from one dashboard.
+          </p>
+          <div class="actions">
+            <a class="button primary" href="#payments">Connect payments</a>
+            <a class="button ghost" href="#termux">Copy Termux prompt</a>
+          </div>
+        </div>
+        <aside class="status-card" aria-live="polite">
+          <span class="status-dot"></span>
+          <h2>Launch Readiness</h2>
+          <div id="readiness-list" class="readiness-list">Loading integration status…</div>
+        </aside>
+      </section>
+    </header>
+
+    <main>
+      <section id="builder" class="section">
+        <div class="section-heading">
+          <p class="eyebrow">Builder workflow</p>
+          <h2>From login to launch, every project gets a guided track.</h2>
+        </div>
+        <div class="cards three">
+          <article class="card">
+            <span class="number">01</span>
+            <h3>Passwordless onboarding</h3>
+            <p>Prepare passkey, Google, Microsoft, or Okta-style sign-in experiences for users and clients.</p>
+          </article>
+          <article class="card">
+            <span class="number">02</span>
+            <h3>AI build assistants</h3>
+            <p>Surface OpenAI, Gemini, and Claude readiness so the platform knows which agent can help.</p>
+          </article>
+          <article class="card">
+            <span class="number">03</span>
+            <h3>DNS and domain board</h3>
+            <p>Track domain selection, DNS setup, verification, workspace email, and launch checklists.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="payments" class="section payment-section">
+        <div class="section-heading">
+          <p class="eyebrow">Upper-tier revenue</p>
+          <h2>Stripe and PayPal checkout hooks are ready for your live credentials.</h2>
+          <p>
+            Pick a tier below. If credentials are missing, the dashboard explains exactly which environment
+            variables to add. Once configured, checkout buttons return live provider links.
+          </p>
+        </div>
+        <div id="tier-grid" class="cards three"></div>
+        <div id="checkout-result" class="checkout-result" role="status"></div>
+      </section>
+
+      <section class="section integration-grid">
+        <article class="card dark">
+          <h2>Connected platform stack</h2>
+          <ul>
+            <li>YouTube training and webinar hub placeholder</li>
+            <li>Elfsight widget-maker launch slot</li>
+            <li>Google Workspace, Microsoft 365, and Okta checklist</li>
+            <li>Cloudflare DNS/security launch lane</li>
+          </ul>
+        </article>
+        <article id="termux" class="card command-card">
+          <h2>Command Codex inside Termux</h2>
+          <p>Run this from Termux after installing Node.js, Git, and Codex CLI:</p>
+          <pre><code>cd ~/RemoVisions-Code-Finders-Platform
+codex "Build RemoVision's dashboard, wire Stripe and PayPal checkout readiness, run npm test if present, commit the changes, and prepare a PR summary."</code></pre>
+          <p class="small">Never paste secret keys into Codex prompts. Put them in <code>.env</code>.</p>
+        </article>
+      </section>
+    </main>
+
+    <script src="/app.js" type="module"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,286 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #07111f;
+  color: #eef6ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(24, 213, 255, 0.24), transparent 36rem),
+    radial-gradient(circle at 80% 10%, rgba(136, 91, 255, 0.24), transparent 28rem),
+    #07111f;
+}
+
+a {
+  color: inherit;
+}
+
+.hero {
+  padding: 1.25rem clamp(1rem, 4vw, 4rem) 4rem;
+}
+
+.nav,
+.hero-grid,
+.section,
+.integration-grid {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 0 3rem;
+}
+
+.nav strong {
+  margin-right: auto;
+  letter-spacing: -0.02em;
+}
+
+.nav a {
+  color: #b8c7da;
+  font-size: 0.95rem;
+  text-decoration: none;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(19rem, 0.75fr);
+  gap: 2rem;
+  align-items: center;
+}
+
+.eyebrow {
+  color: #4be4ff;
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 14ch;
+  font-size: clamp(3rem, 8vw, 6.25rem);
+  line-height: 0.9;
+  letter-spacing: -0.07em;
+}
+
+h2 {
+  font-size: clamp(1.8rem, 4vw, 3rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.lead {
+  max-width: 58rem;
+  color: #c4d2e4;
+  font-size: 1.2rem;
+  line-height: 1.7;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+.button,
+.checkout-button {
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.9rem 1.25rem;
+  font-weight: 800;
+  text-decoration: none;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.button:hover,
+.checkout-button:hover {
+  transform: translateY(-2px);
+}
+
+.primary,
+.checkout-button.stripe {
+  background: linear-gradient(135deg, #4be4ff, #8a6bff);
+  color: #061120;
+}
+
+.ghost,
+.checkout-button.paypal {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #eef6ff;
+}
+
+.status-card,
+.card {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 2rem;
+  background: rgba(10, 24, 43, 0.78);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.24);
+  padding: 1.5rem;
+}
+
+.status-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.status-dot {
+  display: inline-flex;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: #36ff97;
+  box-shadow: 0 0 24px #36ff97;
+}
+
+.readiness-list {
+  display: grid;
+  gap: 0.85rem;
+  margin-top: 1.25rem;
+}
+
+.readiness-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.8rem;
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.75rem;
+  font-weight: 900;
+}
+
+.ready {
+  background: rgba(54, 255, 151, 0.16);
+  color: #78ffb9;
+}
+
+.missing {
+  background: rgba(255, 199, 87, 0.16);
+  color: #ffd37a;
+}
+
+.section {
+  padding: 4rem clamp(1rem, 2vw, 2rem);
+}
+
+.section-heading {
+  max-width: 760px;
+  margin-bottom: 1.5rem;
+}
+
+.section-heading p,
+.card p,
+.card li,
+.small {
+  color: #b8c7da;
+  line-height: 1.65;
+}
+
+.cards {
+  display: grid;
+  gap: 1rem;
+}
+
+.three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.number {
+  color: #4be4ff;
+  font-weight: 900;
+}
+
+.payment-section {
+  border-block: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.tier-price {
+  color: #4be4ff;
+  font-size: 2.5rem;
+  font-weight: 900;
+  letter-spacing: -0.06em;
+}
+
+.checkout-actions {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 1.25rem;
+}
+
+.checkout-result {
+  margin-top: 1rem;
+  min-height: 3rem;
+}
+
+.checkout-result:not(:empty) {
+  border: 1px solid rgba(75, 228, 255, 0.36);
+  border-radius: 1.25rem;
+  background: rgba(75, 228, 255, 0.08);
+  padding: 1rem;
+}
+
+.integration-grid {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 1rem;
+}
+
+.dark {
+  background: linear-gradient(135deg, rgba(75, 228, 255, 0.16), rgba(138, 107, 255, 0.14));
+}
+
+.command-card pre {
+  overflow-x: auto;
+  border-radius: 1rem;
+  background: #020711;
+  color: #bbf7d0;
+  padding: 1rem;
+}
+
+@media (max-width: 850px) {
+  .nav {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .hero-grid,
+  .three,
+  .integration-grid {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: clamp(2.75rem, 16vw, 5rem);
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a lightweight, local dashboard for RemoVision's Code Finders Platform that surfaces AI agent readiness and makes upper-tier payments easy to configure. 
- Give a safe, testable way to prepare Stripe and PayPal checkout flows without embedding secrets in the repo.

### Description

- Added a Node.js server `index.js` that serves static UI from `public/`, exposes `GET /api/config` for readiness, and provides `POST /api/checkout/stripe` and `POST /api/checkout/paypal` endpoints that return setup guidance or create provider sessions when `.env` credentials are present. 
- Implemented a responsive dashboard UI under `public/` (`index.html`, `app.js`, `styles.css`) that renders payment tiers, integration readiness badges, and client-side checkout actions. 
- Updated project docs and examples by adding Stripe/PayPal placeholders to `.env.example`, a `TERMUX.md` guide with the Codex/Termux workflow, and dashboard notes in `README.md` and `SETUP.md`. 
- Added a lightweight `test` script to `package.json` (`node --check index.js`) and included a generated `package-lock.json` for reproducible dependency installation. 

### Testing

- Ran `npm install` and `npm test` successfully, with `node --check index.js` reporting no syntax errors. 
- Launched the server with `PORT=3010 npm start` and validated `GET /api/config` returned the expected readiness payload. 
- Executed `POST /api/checkout/stripe` for the `pro` tier and verified the endpoint returned the expected guidance message when credentials/price IDs are missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a66211f908327944c4dd2ecdc481b)